### PR TITLE
Added secondary camera view

### DIFF
--- a/src/game/camera/components.rs
+++ b/src/game/camera/components.rs
@@ -1,0 +1,4 @@
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct SecondaryCamera;

--- a/src/game/camera/components.rs
+++ b/src/game/camera/components.rs
@@ -2,3 +2,10 @@ use bevy::prelude::*;
 
 #[derive(Component)]
 pub struct SecondaryCamera;
+
+#[derive(States, Debug, Clone, Copy, Eq, PartialEq, Hash, Default)]
+pub enum SecondaryCameraState {
+    #[default]
+    Hidden, // State for the main menu
+    Visible, // State for when the game is running
+}

--- a/src/game/camera/mod.rs
+++ b/src/game/camera/mod.rs
@@ -1,14 +1,20 @@
 use bevy::prelude::*;
-pub use systems::disable_secondary_camera;
-use systems::toggle_secondary_camera;
-mod components;
+use components::SecondaryCameraState;
+pub use systems::{
+    despawn_secondary_camera, toggle_secondary_camera, VIEWPORT_POSITION, VIEWPORT_SIZE,
+};
+
+use super::ui::CameraViewUiPlugin;
+pub mod components;
 mod systems;
 
 pub struct SecondaryCameraPlugin;
 
 impl Plugin for SecondaryCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, systems::spawn_secondary_camera)
+        app.init_state::<SecondaryCameraState>()
+            .add_systems(Startup, systems::spawn_secondary_camera)
+            .add_plugins(CameraViewUiPlugin)
             .add_systems(Update, toggle_secondary_camera);
     }
 }

--- a/src/game/camera/mod.rs
+++ b/src/game/camera/mod.rs
@@ -1,0 +1,14 @@
+use bevy::prelude::*;
+pub use systems::disable_secondary_camera;
+use systems::toggle_secondary_camera;
+mod components;
+mod systems;
+
+pub struct SecondaryCameraPlugin;
+
+impl Plugin for SecondaryCameraPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, systems::spawn_secondary_camera)
+            .add_systems(Update, toggle_secondary_camera);
+    }
+}

--- a/src/game/camera/systems.rs
+++ b/src/game/camera/systems.rs
@@ -1,0 +1,41 @@
+use crate::game::SimulationState;
+
+use super::components::SecondaryCamera;
+use bevy::prelude::*;
+use bevy::render::camera::Viewport;
+
+pub fn spawn_secondary_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)).looking_at(Vec3::ZERO, Vec3::Y),
+        Camera {
+            viewport: Some(Viewport {
+                physical_position: UVec2::new(0, 0),
+                physical_size: UVec2::new(300, 300),
+                ..default()
+            }),
+            order: 1,
+            is_active: false,
+            ..default()
+        },
+        SecondaryCamera,
+    ));
+}
+
+pub fn toggle_secondary_camera(
+    mut camera_query: Query<&mut Camera, With<SecondaryCamera>>,
+    input: Res<ButtonInput<KeyCode>>,
+    simulation_state: Res<State<SimulationState>>,
+) {
+    if *simulation_state.get() == SimulationState::Running && input.just_pressed(KeyCode::Tab) {
+        if let Ok(mut camera) = camera_query.get_single_mut() {
+            camera.is_active = !camera.is_active;
+        }
+    }
+}
+
+pub fn disable_secondary_camera(mut camera_query: Query<&mut Camera, With<SecondaryCamera>>) {
+    if let Ok(mut camera) = camera_query.get_single_mut() {
+        camera.is_active = !camera.is_active;
+    }
+}

--- a/src/game/camera/systems.rs
+++ b/src/game/camera/systems.rs
@@ -1,8 +1,11 @@
 use crate::game::SimulationState;
 
-use super::components::SecondaryCamera;
+use super::components::{SecondaryCamera, SecondaryCameraState};
 use bevy::prelude::*;
 use bevy::render::camera::Viewport;
+
+pub static VIEWPORT_POSITION: [u32; 2] = [5, 5]; // [x, y]
+pub static VIEWPORT_SIZE: [u32; 2] = [300, 300]; // [width, height]
 
 pub fn spawn_secondary_camera(mut commands: Commands) {
     commands.spawn((
@@ -10,8 +13,8 @@ pub fn spawn_secondary_camera(mut commands: Commands) {
         Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)).looking_at(Vec3::ZERO, Vec3::Y),
         Camera {
             viewport: Some(Viewport {
-                physical_position: UVec2::new(0, 0),
-                physical_size: UVec2::new(300, 300),
+                physical_position: UVec2::new(VIEWPORT_POSITION[0], VIEWPORT_POSITION[1]),
+                physical_size: UVec2::new(VIEWPORT_SIZE[0], VIEWPORT_SIZE[1]),
                 ..default()
             }),
             order: 1,
@@ -26,15 +29,26 @@ pub fn toggle_secondary_camera(
     mut camera_query: Query<&mut Camera, With<SecondaryCamera>>,
     input: Res<ButtonInput<KeyCode>>,
     simulation_state: Res<State<SimulationState>>,
+    camera_state: Res<State<SecondaryCameraState>>,
+    mut next_camera_state: ResMut<NextState<SecondaryCameraState>>,
 ) {
     if *simulation_state.get() == SimulationState::Running && input.just_pressed(KeyCode::Tab) {
         if let Ok(mut camera) = camera_query.get_single_mut() {
-            camera.is_active = !camera.is_active;
+            match *camera_state.get() {
+                SecondaryCameraState::Hidden => {
+                    camera.is_active = true;
+                    next_camera_state.set(SecondaryCameraState::Visible);
+                }
+                SecondaryCameraState::Visible => {
+                    camera.is_active = false;
+                    next_camera_state.set(SecondaryCameraState::Hidden);
+                }
+            }
         }
     }
 }
 
-pub fn disable_secondary_camera(mut camera_query: Query<&mut Camera, With<SecondaryCamera>>) {
+pub fn despawn_secondary_camera(mut camera_query: Query<&mut Camera, With<SecondaryCamera>>) {
     if let Ok(mut camera) = camera_query.get_single_mut() {
         camera.is_active = !camera.is_active;
     }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,10 +1,12 @@
 mod biome;
+mod camera;
 mod systems;
 mod ui;
 
 use crate::game::systems::pause_simulation;
 use crate::game::systems::resume_simulation;
 use crate::AppState;
+use camera::{disable_secondary_camera, SecondaryCameraPlugin};
 use systems::*;
 use ui::GameUIPlugin;
 
@@ -29,11 +31,14 @@ impl Plugin for GamePlugin {
                 (resume_simulation, spawn_biome_on_enter),
             )
             // Plugins
-            .add_plugins(GameUIPlugin)
+            .add_plugins((GameUIPlugin, SecondaryCameraPlugin))
             // Systems
             .add_systems(Update, toggle_simulation.run_if(in_state(AppState::Game)))
             // On Exit Systems
-            .add_systems(OnExit(AppState::Game), pause_simulation);
+            .add_systems(
+                OnExit(AppState::Game),
+                (pause_simulation, disable_secondary_camera),
+            );
     }
 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -6,7 +6,7 @@ mod ui;
 use crate::game::systems::pause_simulation;
 use crate::game::systems::resume_simulation;
 use crate::AppState;
-use camera::{disable_secondary_camera, SecondaryCameraPlugin};
+use camera::{despawn_secondary_camera, SecondaryCameraPlugin};
 use systems::*;
 use ui::GameUIPlugin;
 
@@ -37,7 +37,7 @@ impl Plugin for GamePlugin {
             // On Exit Systems
             .add_systems(
                 OnExit(AppState::Game),
-                (pause_simulation, disable_secondary_camera),
+                (pause_simulation, despawn_secondary_camera),
             );
     }
 }

--- a/src/game/ui/camera_view/components.rs
+++ b/src/game/ui/camera_view/components.rs
@@ -1,0 +1,4 @@
+use bevy::prelude::Component;
+
+#[derive(Component)]
+pub struct CameraViewUi {}

--- a/src/game/ui/camera_view/mod.rs
+++ b/src/game/ui/camera_view/mod.rs
@@ -1,0 +1,30 @@
+mod components;
+mod styles;
+mod systems;
+
+use crate::game::camera::components::SecondaryCameraState;
+use crate::AppState;
+use bevy::prelude::*;
+use systems::layout::*;
+
+/// Bevy plugin responsible for managing the camera view UI.
+///
+/// # Functionality
+///
+/// * Spawning and despawning of the camera view UI
+pub struct CameraViewUiPlugin;
+
+impl Plugin for CameraViewUiPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            // Show Camera View UI
+            .add_systems(OnEnter(SecondaryCameraState::Visible), spawn_camera_view_ui)
+            // Hide Camera View UI when exiting visible camera state
+            .add_systems(
+                OnExit(SecondaryCameraState::Visible),
+                despawn_camera_view_ui,
+            )
+            // Hide Camera View UI when exiting the game state
+            .add_systems(OnExit(AppState::Game), despawn_camera_view_ui);
+    }
+}

--- a/src/game/ui/camera_view/styles.rs
+++ b/src/game/ui/camera_view/styles.rs
@@ -1,0 +1,45 @@
+use bevy::prelude::*;
+
+use crate::game::camera::{VIEWPORT_POSITION, VIEWPORT_SIZE};
+
+pub const BACKGROUND_COLOR: Color = Color::srgb(0.13, 0.13, 0.13);
+//pub const TEXT_COLOR: Color = Color::srgb(1.0, 1.0, 1.0);
+
+/// Pause menu parent node style
+pub fn camera_view_parent_style() -> Node {
+    Node {
+        flex_direction: FlexDirection::Column,
+        justify_content: JustifyContent::Center,
+        align_items: AlignItems::Center,
+        width: Val::Px(VIEWPORT_SIZE[0] as f32 + (VIEWPORT_POSITION[0] as f32 * 2.0)),
+        height: Val::Px(VIEWPORT_SIZE[1] as f32 + (VIEWPORT_POSITION[0] as f32 * 2.0)),
+        ..Node::default()
+    }
+}
+/// Camera View Box Border
+pub fn camera_view_style() -> Node {
+    Node {
+        width: Val::Percent(100.0),
+        height: Val::Percent(100.0),
+        border: UiRect::all(Val::Px(VIEWPORT_POSITION[0] as f32)),
+        ..Node::default()
+    }
+}
+
+// /// Function to get the text style and layout
+// ///
+// /// # Arguments
+// ///
+// /// * `font_size` - A `f32` that specifies the size of the font.
+// /// * `asset_server` - A reference to the `AssetServer` resource to load the font asset.
+// ///
+// /// # Returns
+// ///
+// /// * `TextFont` - A `TextFont` struct with the specified font size and loaded font.
+// pub fn get_text_style(font_size: f32, asset_server: &Res<AssetServer>) -> TextFont {
+//     TextFont {
+//         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+//         font_size,
+//         ..TextFont::default()
+//     }
+// }

--- a/src/game/ui/camera_view/systems/layout.rs
+++ b/src/game/ui/camera_view/systems/layout.rs
@@ -1,0 +1,34 @@
+use crate::game::ui::camera_view::components::CameraViewUi;
+use crate::game::ui::camera_view::styles::*;
+use bevy::prelude::*;
+
+pub fn spawn_camera_view_ui(mut commands: Commands) {
+    build_camera_view(&mut commands);
+}
+
+pub fn despawn_camera_view_ui(
+    mut commands: Commands,
+    pause_menu_query: Query<Entity, With<CameraViewUi>>,
+) {
+    if let Ok(pause_menu_entity) = pause_menu_query.get_single() {
+        commands.entity(pause_menu_entity).despawn_recursive();
+    }
+}
+
+fn build_camera_view(commands: &mut Commands) -> Entity {
+    commands
+        .spawn((
+            camera_view_parent_style(),
+            // Camera Style
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                camera_view_style(),
+                BackgroundColor(BACKGROUND_COLOR),
+                BorderColor(Color::BLACK),
+                BorderRadius::all(Val::Px(10.0)),
+                CameraViewUi {},
+            ));
+        })
+        .id()
+}

--- a/src/game/ui/camera_view/systems/mod.rs
+++ b/src/game/ui/camera_view/systems/mod.rs
@@ -1,0 +1,1 @@
+pub mod layout;

--- a/src/game/ui/mod.rs
+++ b/src/game/ui/mod.rs
@@ -1,6 +1,8 @@
+pub mod camera_view;
 mod pause_menu;
 
 use bevy::prelude::*;
+pub use camera_view::CameraViewUiPlugin;
 use pause_menu::PauseMenuPlugin;
 
 pub struct GameUIPlugin;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -15,6 +15,7 @@ pub fn setup(
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        IsDefaultUiCamera,
     ));
 
     // cube


### PR DESCRIPTION
You can now press tab to view a second camera. 

It currently looks at the middle of the screen. 

It also spawns a UI for the camera, but it currently is just a border. 