### PR TITLE
Add mph indicator and CarInput resource for car control abstraction.

### DIFF
--- a/src/game/car/input.rs
+++ b/src/game/car/input.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+
+#[derive(Resource)]
+pub struct CarInput {
+    pub accelerate: bool,
+    pub brake: bool,
+    pub turn_left: bool,
+    pub turn_right: bool,
+    pub toggle_gear: bool,
+}
+
+impl Default for CarInput {
+    fn default() -> Self {
+        Self {
+            accelerate: false,
+            brake: false,
+            turn_left: false,
+            turn_right: false,
+            toggle_gear: false,
+        }
+    }
+}

--- a/src/game/car/mod.rs
+++ b/src/game/car/mod.rs
@@ -1,2 +1,3 @@
 pub mod car;
 pub mod physics;
+pub mod input;

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -2,7 +2,7 @@ mod biome;
 mod camera;
 mod road;
 mod systems;
-mod ui;
+pub mod ui;
 pub mod car;
 
 use crate::game::systems::pause_simulation;

--- a/src/game/ui/mod.rs
+++ b/src/game/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod camera_view;
 mod pause_menu;
 mod speedometer;
+pub mod mph;
 
 use bevy::prelude::*;
 pub use camera_view::CameraViewUiPlugin;

--- a/src/game/ui/mph.rs
+++ b/src/game/ui/mph.rs
@@ -1,0 +1,53 @@
+use bevy::prelude::*;
+
+use crate::game::car::car::*;
+
+#[derive(Component)]
+pub struct SpeedometerText;
+
+
+pub fn spawn_speedometer(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands
+        .spawn((
+            Text::new("Speed: "),
+            TextFont {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font_size: 32.0,
+                ..default()
+            },
+            Node {
+                // Positions the speedometer in the top-right corner
+                position_type: PositionType::Absolute,
+                top: Val::Px(10.0),
+                right: Val::Px(10.0),
+                ..default()
+            },
+        ))
+        .with_child((
+            // Adds a child text span that will display the actual speed
+            TextSpan::default(),
+            TextFont {
+                font_size: 32.0,
+                ..default()
+            },
+            SpeedometerText,
+        ));
+}
+
+pub fn update_speedometer(
+    car_query: Query<&Car>,                                 
+    mut query: Query<&mut TextSpan, With<SpeedometerText>>,
+) {
+    if let Ok(car) = car_query.get_single() {
+        if let Ok(mut span) = query.get_single_mut() {
+            // convert m/s to mph (1 m/s = 2.2369 MPH)
+            let speed_mph = car.current_speed.abs() * 2.2369;
+            // get gear
+            let gear = match car.gear_mode {
+                GearMode::Forward => "D",
+                GearMode::Reverse => "R",
+            };
+            **span = format!("{speed_mph:.1} MPH ({gear})");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use main_menu::MainMenuPlugin;
 use systems::*;
 use game::car::car::*;
 use game::car::physics::*;
+use game::ui::mph::*;
 
 fn main() {
     App::new()
@@ -22,7 +23,8 @@ fn main() {
         .add_systems(Startup, 
             (
                 setup,
-                spawn_car
+                spawn_car,
+                spawn_speedometer,
             )
         )
         .add_systems(
@@ -33,6 +35,7 @@ fn main() {
                 move_car,
                 move_camera,
                 exit_game,
+                update_speedometer,
             ),
         )
         .run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,12 @@ mod systems;
 
 use game::car::car::*;
 use game::car::physics::*;
+use game::car::input::*;
 use game::GamePlugin;
 use main_menu::MainMenuPlugin;
 use systems::*;
 use game::ui::mph::*;
+
 
 fn main() {
     App::new()
@@ -20,6 +22,7 @@ fn main() {
         .add_plugins(GamePlugin)
         // Game Systems
         .insert_resource(ClearColor(Color::srgb(0.2, 0.2, 0.2)))
+        .init_resource::<CarInput>()
         .add_systems(Startup, (setup, spawn_car, spawn_speedometer)
         )
         .add_systems(Update,(move_car, move_camera, exit_game, update_speedometer),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,6 @@ use game::car::physics::*;
 use game::GamePlugin;
 use main_menu::MainMenuPlugin;
 use systems::*;
-use game::car::car::*;
-use game::car::physics::*;
 use game::ui::mph::*;
 
 fn main() {
@@ -22,23 +20,9 @@ fn main() {
         .add_plugins(GamePlugin)
         // Game Systems
         .insert_resource(ClearColor(Color::srgb(0.2, 0.2, 0.2)))
-        .add_systems(Startup, 
-            (
-                setup,
-                spawn_car,
-                spawn_speedometer,
-            )
+        .add_systems(Startup, (setup, spawn_car, spawn_speedometer)
         )
-        .add_systems(
-            Update,
-            (
-                transition_to_game_state,
-                transition_to_main_menu_state,
-                move_car,
-                move_camera,
-                exit_game,
-                update_speedometer,
-            ),
+        .add_systems(Update,(move_car, move_camera, exit_game, update_speedometer),
         )
         .run();
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -8,8 +8,6 @@ pub struct MoveableCamera;
 // Just here for to make sure everything runs right.
 pub fn setup(
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // Camera
     commands.spawn((
@@ -99,3 +97,8 @@ pub fn move_camera(
         }
     }
 }
+
+
+
+
+


### PR DESCRIPTION
MPH indicator was added to the top right of UI (see src/game/ui/mph.rs)

The car control now takes boolean values for turning left and right, accelerating, braking, and toggling gear. All these boolean values default to false (see src/game/car/input.rs). These values are updated with keyboard input in order to provide user control:

    // Update CarInput based on keyboard input
    car_input.accelerate = keyboard_input.pressed(KeyCode::ArrowUp);
    car_input.brake = keyboard_input.pressed(KeyCode::ArrowDown);
    car_input.turn_left = keyboard_input.pressed(KeyCode::ArrowLeft);
    car_input.turn_right = keyboard_input.pressed(KeyCode::ArrowRight);
    car_input.toggle_gear = keyboard_input.just_pressed(KeyCode::KeyG);

This should allow a user to press and hold the break button and stop the car from moving even if values other values are set to true: (needs testing)