### PR TITLE
Add camera state system with car-follow and free modes

### DIFF
--- a/src/game/camera/systems.rs
+++ b/src/game/camera/systems.rs
@@ -1,4 +1,4 @@
-use super::components::{CarFollowCamera, SecondaryCamera, SecondaryCameraState, SecondaryWindow};
+use super::components::*;
 use crate::game::{
     car::car::Car,
     python::{
@@ -9,8 +9,8 @@ use crate::game::{
 };
 use bevy::{
     prelude::*,
-    render::camera::{Exposure, PhysicalCameraParameters, RenderTarget, Viewport},
-    window::{EnabledButtons, WindowRef, WindowResolution},
+    render::camera::*,
+    window::*,
 };
 
 // Viewport configuration

--- a/src/game/car/mod.rs
+++ b/src/game/car/mod.rs
@@ -19,7 +19,7 @@ impl Plugin for CarPlugin {
             .add_systems(OnEnter(AppState::Game), spawn_car)
             // Hide Camera View UI when exiting visible camera state
             .add_systems(
-                Update,
+                FixedUpdate,
                 (move_car, reset_car, car_commands, handle_car_commands)
                     .run_if(in_state(AppState::Game)),
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,22 @@ fn main() {
         // Bevy Plugins
         .add_plugins(DefaultPlugins)
         .init_state::<AppState>()
+        .init_state::<CameraState>()
         // Game Plugins
         .add_plugins(MainMenuPlugin)
         .add_plugins(GamePlugin)
         // Game Systems
         .insert_resource(ClearColor(Color::srgb(0.2, 0.2, 0.2)))
         .add_systems(Startup, setup)
-        .add_systems(Update, (move_camera, exit_game))
+        .add_systems(Update, (change_camera_state, exit_game))
+        // Camera Systems
+        .add_systems(FixedUpdate, update_car_camera // MUST be FixedUpdate to prevent jitter
+            .run_if(in_state(AppState::Game))
+            .run_if(in_state(CameraState::CarCam)))
+        .add_systems(FixedUpdate, move_camera
+            .run_if(in_state(AppState::Game))
+            .run_if(in_state(CameraState::FreeCam))
+        )
         .run();
 }
 
@@ -28,4 +37,11 @@ pub enum AppState {
     MainMenu, // State for the main menu
     Game,     // State for when the game is running
     GameOver, // We dont use this for anything yet :)
+}
+
+#[derive(States, Debug, Clone, Copy, Eq, PartialEq, Hash, Default)]
+pub enum CameraState {
+    #[default]
+    CarCam,
+    FreeCam
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,8 +1,9 @@
 /// Author: John Klucinec (@johnklucinec)
 use bevy::{
-    prelude::*,
-    render::camera::{Exposure, PhysicalCameraParameters},
+    prelude::*, render::camera::{Exposure, PhysicalCameraParameters}
 };
+
+use crate::{game::car::car::Car, CameraState};
 
 #[derive(Component)]
 pub struct MoveableCamera;
@@ -40,6 +41,36 @@ pub fn setup(mut commands: Commands) {
     });
 }
 
+pub fn update_car_camera(
+    car_query: Query<&Transform, With<Car>>,
+    time: Res<Time>,
+    mut camera_query: Query<&mut Transform, (With<MoveableCamera>, Without<Car>)>,
+) {
+    match (car_query.get_single(), camera_query.get_single_mut()) {
+        (Ok(car_transform), Ok(mut camera_transform)) => {
+
+            let detla_time = time.delta_secs();
+            // Calculate offset based on car's rotation
+            let back_offset = car_transform.back() * 10.0; // Multiply by distance behind car
+            let up_offset = car_transform.up() * 6.0; // Multiply by height above car
+
+            // Position camera behind and above car
+            let target_position = car_transform.translation + back_offset + up_offset;
+            let smoothness = 5.0;
+
+            // Smoothly move camera towards target position
+            camera_transform.translation = camera_transform.translation.lerp(
+                target_position,
+                detla_time * smoothness);
+
+            // Look at the car
+            camera_transform.look_at(car_transform.translation, Vec3::Y);
+        }
+        (Err(_), _) => warn!("No car found with Car component"),
+        (_, Err(_)) => warn!("No camera found with SecondaryCamera component"),
+    }
+}
+
 /// Exits the game when the 'ALT + F4' key is pressed.
 pub fn exit_game(
     keyboard_input: Res<ButtonInput<KeyCode>>,
@@ -52,6 +83,22 @@ pub fn exit_game(
     }
 }
 
+pub fn change_camera_state(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut camera_state: ResMut<NextState<CameraState>>,
+) {
+    let car_cam_pressed = keyboard_input.just_pressed(KeyCode::Digit1);
+    let free_cam_pressed = keyboard_input.just_pressed(KeyCode::Digit2);
+
+    if car_cam_pressed {
+        camera_state.set(CameraState::CarCam);
+        println!("Switched to CarCam");
+    } else if free_cam_pressed {
+        camera_state.set(CameraState::FreeCam);
+        println!("Switched to FreeCam");
+    }
+}
+
 pub fn move_camera(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut camera_query: Query<&mut Transform, With<MoveableCamera>>,
@@ -61,27 +108,17 @@ pub fn move_camera(
         let movement_speed = 8.0;
         let delta = time.delta_secs() * movement_speed;
 
-        if keyboard_input.pressed(KeyCode::KeyA) {
-            transform.translation.x -= delta;
-        }
-        if keyboard_input.pressed(KeyCode::KeyD) {
-            transform.translation.x += delta;
-        }
-        if keyboard_input.pressed(KeyCode::KeyW) {
-            transform.translation.z -= delta;
-        }
-        if keyboard_input.pressed(KeyCode::KeyS) {
-            transform.translation.z += delta;
-        }
+        // Handle WASD (world axes)
+        if keyboard_input.pressed(KeyCode::KeyA) { transform.translation.x -= delta; }
+        if keyboard_input.pressed(KeyCode::KeyD) { transform.translation.x += delta; }
+        if keyboard_input.pressed(KeyCode::KeyW) { transform.translation.z -= delta; }
+        if keyboard_input.pressed(KeyCode::KeyS) { transform.translation.z += delta; }
 
-        if keyboard_input.pressed(KeyCode::KeyQ) {
+        // Handle QE (local up/down)
+        if keyboard_input.pressed(KeyCode::KeyQ) || keyboard_input.pressed(KeyCode::KeyE) {
             let up_direction = transform.up();
-            transform.translation -= up_direction * delta;
-        }
-
-        if keyboard_input.pressed(KeyCode::KeyE) {
-            let up_direction = transform.up();
-            transform.translation += up_direction * delta;
+            if keyboard_input.pressed(KeyCode::KeyQ) { transform.translation -= up_direction * delta; }
+            if keyboard_input.pressed(KeyCode::KeyE) { transform.translation += up_direction * delta; }
         }
     }
 }


### PR DESCRIPTION
The changes add a new camera state system with two modes: a car-following camera and a free-moving camera that can be toggled with number keys 1 and 2. The car camera smoothly follows behind and above the vehicle.